### PR TITLE
declare class properties

### DIFF
--- a/SeasSnowflake.cpp
+++ b/SeasSnowflake.cpp
@@ -94,6 +94,8 @@ PHP_MINIT_FUNCTION(SeasSnowflake)
     INIT_CLASS_ENTRY(SeasSnowflake, SEASSNOWFLAKE_RES_NAME, SeasSnowflake_methods);
 #if PHP_VERSION_ID >= 70000
     SeasSnowflake_ce = zend_register_internal_class_ex(&SeasSnowflake, NULL);
+    zend_declare_property_null(SeasSnowflake_ce, "worker_id", sizeof("worker_id")-1, ZEND_ACC_PUBLIC);
+    zend_declare_property_null(SeasSnowflake_ce, "datacenter_id", sizeof("datacenter_id")-1, ZEND_ACC_PUBLIC);
 #else
     SeasSnowflake_ce = zend_register_internal_class_ex(&SeasSnowflake, NULL, NULL TSRMLS_CC);
 #endif


### PR DESCRIPTION
This work on all PHP versions but become mandatory with PHP 8.2

Without all tests are failing, example
```
========DIFF========
001+ Deprecated: Creation of dynamic property SeasSnowflake::$worker_id is deprecated in /work/GIT/pecl-and-ext/SeasSnowflake/tests/003.php on line 8
002+ 
003+ Deprecated: Creation of dynamic property SeasSnowflake::$datacenter_id is deprecated in /work/GIT/pecl-and-ext/SeasSnowflake/tests/003.php on line 8
     array
========DONE========
FAIL SeasSnowflake testCreateId [tests/003.phpt] 

```

With
```
=====================================================================
PHP         : /opt/remi/php82/root/usr/bin/php 
PHP_SAPI    : cli
PHP_VERSION : 8.2.0RC2
ZEND_VERSION: 4.2.0RC2
PHP_OS      : Linux - Linux builder.remirepo.net 5.19.8-100.fc35.x86_64 #1 SMP PREEMPT_DYNAMIC Thu Sep 8 19:23:03 UTC 2022 x86_64
INI actual  : /work/GIT/pecl-and-ext/SeasSnowflake/tmp-php.ini
More .INIs  :  
---------------------------------------------------------------------
PHP         : /opt/remi/php82/root/usr/bin/php-cgi 
PHP_SAPI    : cgi-fcgi
PHP_VERSION : 8.2.0RC2
ZEND_VERSION: 4.2.0RC2
PHP_OS      : Linux - Linux builder.remirepo.net 5.19.8-100.fc35.x86_64 #1 SMP PREEMPT_DYNAMIC Thu Sep 8 19:23:03 UTC 2022 x86_64
INI actual  : /work/GIT/pecl-and-ext/SeasSnowflake/tmp-php.ini
More .INIs  : 
--------------------------------------------------------------------- 
CWD         : /work/GIT/pecl-and-ext/SeasSnowflake
Extra dirs  : 
VALGRIND    : Not used
=====================================================================
TIME START 2022-09-15 07:02:03
=====================================================================
PASS Check for SeasSnowflake presence [tests/001.phpt] 
PASS SeasSnowflake testCreateId [tests/002.phpt] 
PASS SeasSnowflake testCreateId [tests/003.phpt] 
PASS SeasSnowflake testCreateId [tests/004.phpt] 
PASS SeasSnowflake testBenchmark [tests/benchmark.phpt] 
=====================================================================
TIME END 2022-09-15 07:02:03

=====================================================================
TEST RESULT SUMMARY
---------------------------------------------------------------------
Exts skipped    :    0
Exts tested     :   17
---------------------------------------------------------------------

Number of tests :    5                 5
Tests skipped   :    0 (  0.0%) --------
Tests warned    :    0 (  0.0%) (  0.0%)
Tests failed    :    0 (  0.0%) (  0.0%)
Tests passed    :    5 (100.0%) (100.0%)
---------------------------------------------------------------------
Time taken      :    0 seconds
=====================================================================

```